### PR TITLE
Add optional Laravel version support

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -44,6 +44,7 @@ class NewCommand extends Command
             ->setName('new')
             ->setDescription('Create a new Laravel application')
             ->addArgument('name', InputArgument::REQUIRED)
+            ->addOption('v', null, InputOption::VALUE_OPTIONAL, 'Install a specific Laravel version instead of the latest (e.g. --v=11.*)')
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Install the latest "development" release')
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository', $this->defaultBranch())
@@ -822,11 +823,16 @@ class NewCommand extends Command
      */
     protected function getVersion(InputInterface $input)
     {
+        // Check if the --v option is provided
+        if ($input->getOption('v')) {
+            return $input->getOption('v');
+        }
+
         if ($input->getOption('dev')) {
             return 'dev-master';
         }
 
-        return '';
+        return ''; # Default to the latest stable version
     }
 
     /**


### PR DESCRIPTION
Implemented the --v option as optional. Users can now install a specific Laravel version (e.g., --v 11.*). If the option is provided without a value, the installer defaults to the latest Laravel version.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
